### PR TITLE
use %in% when edgeNum is vector

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -73,7 +73,7 @@ jplace_treetext_to_phylo <- function(tree.text) {
 edgeNum2nodeNum <- function(jp, edgeNum) {
     edges <- attr(jp@phylo, "edgeNum")
 
-    idx <- which(edges$edgeNum == edgeNum)
+    idx <- which(edges$edgeNum %in% edgeNum)
     if (length(idx) == 0) {
         return(NA)
     }


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
replace `==` with `%in%`, when the `edgeNum` is vector in `edgeNum2nodeNum`
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

