### PR TITLE
support multi phylogeny in phyloxml and extra information

### DIFF
--- a/R/phyloxml.R
+++ b/R/phyloxml.R
@@ -1,56 +1,144 @@
 #' @title read.phyloxml
 #' @param file phyloxml file
-#' @return treedata class
+#' @return treedata class or multitreedata class
 #' @export
 #' @examples
 #' xmlfile <- system.file("extdata/phyloxml", "test_x2.xml", package="treeio")
 #' px <- read.phyloxml(xmlfile)
 #' px
+#' xmlfile2 <- system.file("extdata/phyloxml", "phyloxml_examples.xml", package="treeio")
+#' px2 <- read.phyloxml(xmlfile2)
+#' class(px2)
 read.phyloxml <- function(file){
     x <- xml2::read_xml(file)
-    x <- xml2::xml_root(x)
-    phylogeny <- xml2::as_list(x)[["phyloxml"]]
-
-    clade <- phylogeny[["phylogeny"]][["clade"]]
-    dt <- parser_clade(clade)
-    dt <- dt[!is.na(dt$nodeid),]
-    edgedf <- dt[,c("nodeid", "child", "edge.length")]
-    dt <- dplyr::mutate(dt, label = as.character(.data$child))
-    dd <- as.phylo(edgedf, "edge.length") %>% as_tibble() %>%
-          dplyr::full_join(dt, by='label')  
-    obj <- dd %>% dplyr::mutate(label=as.vector(.data$labelnames)) %>% 
-           dplyr::select(-c("nodeid", "child", "edge.length", "labelnames")) %>%
-           as.treedata
-    obj@file <- filename(file)
+    x <- xml2::as_list(x)
+    x <- x[["phyloxml"]]
+    index <- which(names(x)=="phylogeny")
+    if (length(index)==0){
+        stop("The input file is not phyloxml format, please check it !")
+    }
+    if (length(index)==1){
+        obj <- single_tree(x[[index]], file)
+    }else{
+        obj <- lapply(x[index], single_tree, file)
+        class(obj) <- "multitreedata"
+    }
     return(obj)
 }
 
 #' @keywords internal
+single_tree <- function(phylogeny, file){
+    dt <- parser_clade(phylogeny[["clade"]])
+    dt <- dt[!is.na(dt$parentID), ]
+    if ("branch_length" %in% colnames(dt)){
+        edgedf <- dt[,c("parentID", "NodeID", "branch_length")]
+        rmclumn <- c("parentID", "branch_length")
+    }else{
+        edgedf <- dt[,c("parentID", "NodeID")]
+        rmclumn <- c("parentID")
+    }
+    dt <- dplyr::mutate(dt, label = as.character(dt$NodeID))
+    dd <- as.phylo(edgedf, "branch_length") %>% as_tibble() %>%
+            dplyr::full_join(dt, by='label')
+    if ("accession" %in% colnames(dd)){
+        dd$label <- as.vector(dd$accession)
+    }else{
+        if ("name" %in% colnames(dd)){
+            dd$label <- as.vector(dd$name)
+        }
+        if ( "scientific_name" %in% colnames(dd) & !"name"%in%colnames(dd)){
+            dd$label <- as.vector(dd$scientific_name)
+	}
+    }
+    obj <- dd %>% dplyr::select(-rmclumn) %>% as.treedata
+    obj@file <- filename(file)
+    return(obj)
+}
+
+
+#' @keywords internal
 parser_clade <- function(x, id=list2env(list(id = 0L)), parent=NULL){
     id[["id"]] <- id[["id"]] + 1L
-    tmpdf <- data.frame(nodeid = checkvalue(parent),
-                        child = id[["id"]],
-                        edge.length=checkvalue(x[["branch_length"]]),
-                        labelnames=checkvalue(x[["name"]]))
+    id[["data"]][[id[["id"]]]] <- extract_values_attrs(x, id=id[["id"]], isTip=FALSE, parent=fill_id(parent))
     index <- which(names(x)=="clade")
-    clades <- lapply(x[index], parser_clade, id=id, parent=tmpdf$child)
-    clades <- do.call("rbind", clades)
-    return(rbind(tmpdf, clades, make.row.names=FALSE))
+    if (length(index)){
+        lapply(x[index], parser_clade, id=id, parent=id[["data"]][[id[["id"]]-1L]][["NodeID"]])
+    }else{
+        id[["data"]][[id[["id"]]]][["isTip"]] <- TRUE
+    }
+    dat <- dplyr::bind_rows(as.list(id[["data"]]))
+    return(dat)
 }
 
 #' @keywords internal
-checkvalue <- function(x){
-    n <- length(x)
-    if (n == 0) return(NA)
-    if (inherits(x, "list")) {
-        if (n == 1) {
-            x <- x[[1]]
-        }
-    }
-    
-    if (inherits(x, "list")) {
-        lapply(x, checkvalue)    
-    } else {
-        unlist(x)
+fill_id <- function(x){
+    if (is.list(x)) {
+        lapply(x, fill_id)
+    }else{
+        ifelse(length(x), unlist(x), NA)
     }
 }
+
+#' @keywords internal
+extract_another <- function(x){
+    namestmp <- names(x)
+    index <- which(namestmp != "clade")
+    namestmp <- namestmp[index]
+    namestmp2 <- namestmp
+    dind <- which(duplicated(namestmp2)|duplicated(namestmp2, fromLast=TRUE))
+    if (length(dind)){
+        namestmp2 <- mapply(paste0, namestmp2[dind], 
+                            seq_len(length(dind)), SIMPLIFY=FALSE)
+    }
+    if (length(index)){
+        lapply(index, function(i){
+                      attrs <- check_attrs(x[[i]])
+                      values <- check_value(x[[i]])
+                      if (length(values)!=0 & length(names(values))==0){
+                          names(values) <- namestmp2[i]
+                      }
+                      c(values, attrs)
+              })
+    
+    }
+}
+
+#' @keywords internal
+check_attrs <- function(x){
+    namesattrs <- names(attributes(x))
+    index <- which(namesattrs != "names")
+    if (length(index)){
+        unlist(attributes(x)[index])
+    }
+}
+
+#' @keywords internal
+check_value <- function(x){
+    if (inherits(x, "list")){
+        lapply(x, check_value)
+    }else{
+        if(length(x)>2){
+            lapply(x, check_value)
+	}else{
+            list(check_attrs(x), unlist(x))
+        }
+    }
+}
+
+#' @keywords internal
+extract_values_attrs <- function(x, id, parent, isTip){
+    attr <- check_attrs(x)
+    anothers <- unlist(extract_another(x))
+    res <- c(attr, anothers)
+    if (!is.null(res)){
+       res <- data.frame(t(res), check.names=FALSE, stringsAsFactors=FALSE)
+       res$parentID <- parent
+       res$NodeID <- id
+       res$isTip <- isTip
+    }else{
+       res <- data.frame(parentID=parent, NodeID=id, isTip=isTip,
+                         check.names=FALSE, stringsAsFactors=FALSE)
+    }
+    return(res)
+}
+

--- a/inst/extdata/phyloxml/phyloxml_examples.xml
+++ b/inst/extdata/phyloxml/phyloxml_examples.xml
@@ -1,0 +1,416 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phyloxml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.phyloxml.org http://www.phyloxml.org/1.10/phyloxml.xsd"
+   xmlns="http://www.phyloxml.org">
+   <phylogeny rooted="true">
+      <name>example from Prof. Joe Felsenstein's book "Inferring Phylogenies"</name>
+      <description>phyloXML allows to use either a "branch_length" attribute or element to indicate branch lengths.</description>
+      <clade>
+         <clade branch_length="0.06">
+            <clade branch_length="0.102">
+               <name>A</name>
+            </clade>
+            <clade branch_length="0.23">
+               <name>B</name>
+            </clade>
+         </clade>
+         <clade branch_length="0.4">
+            <name>C</name>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>example from Prof. Joe Felsenstein's book "Inferring Phylogenies"</name>
+      <description>phyloXML allows to use either a "branch_length" attribute or element to indicate branch lengths.</description>
+      <clade>
+         <clade>
+            <branch_length>0.06</branch_length>
+            <clade>
+               <name>A</name>
+               <branch_length>0.102</branch_length>
+            </clade>
+            <clade>
+               <name>B</name>
+               <branch_length>0.23</branch_length>
+            </clade>
+         </clade>
+         <clade>
+            <name>C</name>
+            <branch_length>0.4</branch_length>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>same example, with support of type "bootstrap"</name>
+      <clade>
+         <clade branch_length="0.06">
+            <name>AB</name>
+            <confidence type="bootstrap">89</confidence>
+            <clade branch_length="0.102">
+               <name>A</name>
+            </clade>
+            <clade branch_length="0.23">
+               <name>B</name>
+            </clade>
+         </clade>
+         <clade branch_length="0.4">
+            <name>C</name>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>same example, with species and sequence</name>
+      <clade>
+         <clade>
+            <name>AB</name>
+            <clade>
+               <name>A</name>
+               <taxonomy>
+                  <scientific_name>E. coli</scientific_name>
+               </taxonomy>
+               <sequence>
+                  <annotation>
+                     <desc>alcohol dehydrogenase</desc>
+                     <confidence type="probability">0.99</confidence>
+                  </annotation>
+               </sequence>
+            </clade>
+            <clade>
+               <name>B</name>
+               <taxonomy>
+                  <scientific_name>B. subtilis</scientific_name>
+               </taxonomy>
+               <sequence>
+                  <annotation>
+                     <desc>alcohol dehydrogenase</desc>
+                     <confidence type="probability">0.91</confidence>
+                  </annotation>
+               </sequence>
+            </clade>
+         </clade>
+         <clade>
+            <name>C</name>
+            <taxonomy>
+               <scientific_name>C. elegans</scientific_name>
+            </taxonomy>
+            <sequence>
+               <annotation>
+                  <desc>alcohol dehydrogenase</desc>
+                  <confidence type="probability">0.67</confidence>
+               </annotation>
+            </sequence>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>same example, with gene duplication information and sequence relationships</name>
+      <clade>
+         <events>
+            <speciations>1</speciations>
+         </events>
+         <clade>
+            <events>
+               <duplications>1</duplications>
+            </events>
+            <clade>
+               <taxonomy>
+                  <scientific_name>Bacillus subtilis</scientific_name>
+               </taxonomy>
+               <sequence id_source="x">
+                  <symbol>adhB</symbol>
+                  <accession source="ncbi">AAB80874</accession>
+                  <name>alcohol dehydrogenase</name>
+               </sequence>
+            </clade>
+            <clade>
+               <taxonomy>
+                  <scientific_name>Bacillus subtilis</scientific_name>
+               </taxonomy>
+               <sequence id_source="y">
+                  <symbol>gbsB</symbol>
+                  <accession source="ncbi">CAB15083</accession>
+                  <name>alcohol dehydrogenase</name>
+               </sequence>
+            </clade>
+         </clade>
+         <clade>
+            <taxonomy>
+               <scientific_name>Caenorhabditis elegans</scientific_name>
+            </taxonomy>
+            <sequence id_source="z">
+               <symbol>ADHX</symbol>
+               <accession source="ncbi">Q17335</accession>
+               <name>alcohol dehydrogenase</name>
+               <annotation ref="InterPro:IPR002085"/>
+            </sequence>
+         </clade>
+      </clade>
+      <sequence_relation id_ref_0="x" id_ref_1="y" type="paralogy"/>
+      <sequence_relation id_ref_0="x" id_ref_1="z" type="orthology"/>
+      <sequence_relation id_ref_0="y" id_ref_1="z" type="orthology"/>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>similar example, with more detailed sequence data</name>
+      <clade>
+         <clade>
+            <clade>
+               <taxonomy>
+                  <id provider="NCBI">6645</id>
+                  <code>OCTVU</code>
+                  <scientific_name>Octopus vulgaris</scientific_name>
+               </taxonomy>
+               <sequence>
+                  <symbol>ADHX</symbol>
+                  <accession source="UniProtKB">P81431</accession>
+                  <name>Alcohol dehydrogenase class-3</name>
+                  <mol_seq>TDATGKPIKCMAAIAWEAKKPLSIEEVEVAPPKSGEVRIKILHSGVCHTD</mol_seq>
+                  <annotation ref="EC:1.1.1.1"/>
+                  <annotation ref="GO:0004022"/>
+               </sequence>
+            </clade>
+            <clade>
+               <taxonomy>
+                  <id provider="NCBI">44689</id>
+                  <code>DICDI</code>
+                  <scientific_name>Dictyostelium discoideum</scientific_name>
+               </taxonomy>
+               <sequence>
+                  <symbol>RT4I1</symbol>
+                  <accession source="UniProtKB">Q54II4</accession>
+                  <name>Reticulon-4-interacting protein 1 homolog, mitochondrial precursor</name>
+                  <mol_seq>MKGILLNGYGESLDLLEYKTDLPVPKPIKSQVLIKIHSTSINPLDNVMRK</mol_seq>
+                  <annotation ref="GO:0008270"/>
+                  <annotation ref="GO:0016491"/>
+               </sequence>
+            </clade>
+         </clade>
+         <clade>
+            <taxonomy>
+               <id provider="NCBI">1488</id>
+               <code>CLOAB</code>
+               <scientific_name>Clostridium acetobutylicum</scientific_name>
+            </taxonomy>
+            <sequence>
+               <symbol>ADHB</symbol>
+               <accession source="UniProtKB">Q04945</accession>
+               <name>NADH-dependent butanol dehydrogenase B</name>
+               <mol_seq>MVDFEYSIPTRIFFGKDKINVLGRELKKYGSKVLIVYGGGSIKRNGIYDK</mol_seq>
+               <annotation ref="GO:0046872"/>
+               <annotation ref="KEGG:Tetrachloroethene degradation"/>
+            </sequence>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="false">
+      <name>network, node B is connected to TWO nodes: AB and C</name>
+      <clade>
+         <clade id_source="ab" branch_length="0.06">
+            <name>AB</name>
+            <clade id_source="a" branch_length="0.102">
+               <name>A</name>
+            </clade>
+            <clade id_source="b" branch_length="0.23">
+               <name>B</name>
+            </clade>
+         </clade>
+         <clade id_source="c" branch_length="0.4">
+            <name>C</name>
+         </clade>
+      </clade>
+      <clade_relation id_ref_0="b" id_ref_1="c" type="network_connection"/>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>same example, using property elements to indicate a "depth" value for marine organisms</name>
+      <clade>
+         <clade>
+            <name>AB</name>
+            <clade>
+               <name>A</name>
+               <property datatype="xsd:integer" ref="NOAA:depth" applies_to="clade" unit="METRIC:m"> 1200 </property>
+            </clade>
+            <clade>
+               <name>B</name>
+               <property datatype="xsd:integer" ref="NOAA:depth" applies_to="clade" unit="METRIC:m"> 2300 </property>
+            </clade>
+         </clade>
+         <clade>
+            <name>C</name>
+            <property datatype="xsd:integer" ref="NOAA:depth" applies_to="clade" unit="METRIC:m"> 200 </property>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>same example, using property elements to indicate a "depth" value for marine organisms by using id refs in
+         order to have property elements outside of the tree topology</name>
+      <clade>
+         <clade>
+            <name>AB</name>
+            <clade id_source="id_a">
+               <name>A</name>
+            </clade>
+            <clade id_source="id_b">
+               <name>B</name>
+            </clade>
+         </clade>
+         <clade id_source="id_c">
+            <name>C</name>
+         </clade>
+      </clade>
+      <property id_ref="id_a" datatype="xsd:integer" ref="NOAA:depth" applies_to="node" unit="METRIC:m"> 1200 </property>
+      <property id_ref="id_b" datatype="xsd:integer" ref="NOAA:depth" applies_to="node" unit="METRIC:m"> 2300 </property>
+      <property id_ref="id_c" datatype="xsd:integer" ref="NOAA:depth" applies_to="node" unit="METRIC:m"> 200 </property>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>monitor lizards</name>
+      <description>a pylogeny of some monitor lizards</description>
+      <clade>
+         <taxonomy>
+            <id provider="NCBI">8556</id>
+            <scientific_name>Varanus</scientific_name>
+            <rank>genus</rank>
+            <uri desc="EMBL REPTILE DATABASE">http://www.embl-heidelberg.de/~uetz/families/Varanidae.html</uri>
+         </taxonomy>
+         <clade>
+            <taxonomy>
+               <id provider="NCBI">62046</id>
+               <scientific_name>Varanus niloticus</scientific_name>
+               <common_name>Nile monitor</common_name>
+               <rank>species</rank>
+            </taxonomy>
+            <distribution>
+               <desc>Africa</desc>
+            </distribution>
+         </clade>
+         <clade>
+            <taxonomy>
+               <scientific_name>Odatria</scientific_name>
+               <rank>subgenus</rank>
+            </taxonomy>
+            <clade>
+               <taxonomy>
+                  <id provider="NCBI">169855</id>
+                  <scientific_name>Varanus storri</scientific_name>
+                  <common_name>Storr's monitor</common_name>
+                  <rank>species</rank>
+               </taxonomy>
+               <distribution>
+                  <desc>Australia</desc>
+               </distribution>
+            </clade>
+            <clade>
+               <taxonomy>
+                  <id provider="NCBI">62053</id>
+                  <scientific_name>Varanus timorensis</scientific_name>
+                  <common_name>Timor monitor</common_name>
+                  <rank>species</rank>
+               </taxonomy>
+               <distribution>
+                  <desc>Asia</desc>
+               </distribution>
+            </clade>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>A tree with phylogeographic information</name>
+      <clade>
+         <clade>
+            <clade>
+               <name>A</name>
+               <distribution>
+                  <desc>Hirschweg, Winterthur, Switzerland</desc>
+                  <point geodetic_datum="WGS84" alt_unit="m">
+                     <lat>47.481277</lat>
+                     <long>8.769303</long>
+                     <alt>472</alt>
+                  </point>
+               </distribution>
+            </clade>
+            <clade>
+               <name>B</name>
+               <distribution>
+                  <desc>Nagoya, Aichi, Japan</desc>
+                  <point geodetic_datum="WGS84" alt_unit="m">
+                     <lat>35.155904</lat>
+                     <long>136.915863</long>
+                     <alt>10</alt>
+                  </point>
+               </distribution>
+            </clade>
+            <clade>
+               <name>C</name>
+               <distribution>
+                  <desc>ETH Zürich</desc>
+                  <point geodetic_datum="WGS84" alt_unit="m">
+                     <lat>47.376334</lat>
+                     <long>8.548108</long>
+                     <alt>452</alt>
+                  </point>
+               </distribution>
+            </clade>
+         </clade>
+         <clade>
+            <name>D</name>
+            <distribution>
+               <desc>San Diego</desc>
+               <point geodetic_datum="WGS84" alt_unit="m">
+                  <lat>32.880933</lat>
+                  <long>-117.217543</long>
+                  <alt>104</alt>
+               </point>
+            </distribution>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>A tree with date information</name>
+      <clade>
+         <clade>
+            <clade>
+               <name>A</name>
+               <date unit="mya">
+                  <desc>Silurian</desc>
+                  <value>425</value>
+                  <minimum>416.0</minimum>
+                  <maximum>443.7</maximum>
+               </date>
+            </clade>
+            <clade>
+               <name>B</name>
+               <date unit="mya">
+                  <desc>Devonian</desc>
+                  <value>320</value>
+               </date>
+            </clade>
+         </clade>
+         <clade>
+            <name>C</name>
+            <date unit="mya">
+               <desc>Ediacaran</desc>
+               <value>600</value>
+            </date>
+         </clade>
+      </clade>
+   </phylogeny>
+   <phylogeny rooted="true">
+      <name>Using another XML language to store an alignment</name>
+      <clade>
+         <clade>
+            <clade>
+               <name>A</name>
+            </clade>
+            <clade>
+               <name>B</name>
+            </clade>
+         </clade>
+         <clade>
+            <name>C</name>
+         </clade>
+      </clade>
+   </phylogeny>
+   <align:alignment xmlns:align="http://example.org/align">
+      <seq name="A">acgtcgcggcccgtggaagtcctctcct</seq>
+      <seq name="B">aggtcgcggcctgtggaagtcctctcct</seq>
+      <seq name="C">taaatcgc--cccgtgg-agtccc-cct</seq>
+   </align:alignment>
+</phyloxml>

--- a/man/read.phyloxml.Rd
+++ b/man/read.phyloxml.Rd
@@ -10,7 +10,7 @@ read.phyloxml(file)
 \item{file}{phyloxml file}
 }
 \value{
-treedata class
+treedata class or multitreedata class
 }
 \description{
 read.phyloxml
@@ -19,4 +19,7 @@ read.phyloxml
 xmlfile <- system.file("extdata/phyloxml", "test_x2.xml", package="treeio")
 px <- read.phyloxml(xmlfile)
 px
+xmlfile2 <- system.file("extdata/phyloxml", "phyloxml_examples.xml", package="treeio")
+px2 <- read.phyloxml(xmlfile2)
+class(px2)
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -37,14 +37,14 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{ape}{\code{\link[ape]{as.phylo}}, \code{\link[ape]{is.rooted}}, \code{\link[ape]{Nnode}}, \code{\link[ape]{Ntip}}, \code{\link[ape]{read.nexus}}, \code{\link[ape]{read.tree}}, \code{\link[ape]{root}}, \code{\link[ape]{rtree}}, \code{\link[ape]{write.nexus}}, \code{\link[ape]{write.tree}}}
+  \item{ape}{\code{\link[ape]{read.tree}}, \code{\link[ape]{read.nexus}}, \code{\link[ape]{rtree}}, \code{\link[ape]{write.tree}}, \code{\link[ape]{write.nexus}}, \code{\link[ape]{Nnode}}, \code{\link[ape]{Ntip}}, \code{\link[ape]{is.rooted}}, \code{\link[ape]{root}}, \code{\link[ape]{as.phylo}}}
 
   \item{dplyr}{\code{\link[dplyr]{full_join}}}
 
   \item{magrittr}{\code{\link[magrittr]{\%>\%}}}
 
-  \item{tibble}{\code{\link[tibble]{as_tibble}}, \code{\link[tibble]{data_frame}}}
+  \item{tibble}{\code{\link[tibble]{data_frame}}, \code{\link[tibble]{as_tibble}}}
 
-  \item{tidytree}{\code{\link[tidytree]{ancestor}}, \code{\link[tidytree]{as.treedata}}, \code{\link[tidytree]{child}}, \code{\link[tidytree]{get.data}}, \code{\link[tidytree]{get.fields}}, \code{\link[tidytree]{MRCA}}, \code{\link[tidytree]{nodeid}}, \code{\link[tidytree]{nodelab}}, \code{\link[tidytree]{offspring}}, \code{\link[tidytree]{parent}}, \code{\link[tidytree]{rootnode}}, \code{\link[tidytree]{treedata}}}
+  \item{tidytree}{\code{\link[tidytree]{treedata}}, \code{\link[tidytree]{get.fields}}, \code{\link[tidytree]{get.data}}, \code{\link[tidytree]{as.treedata}}, \code{\link[tidytree]{ancestor}}, \code{\link[tidytree]{parent}}, \code{\link[tidytree]{child}}, \code{\link[tidytree]{offspring}}, \code{\link[tidytree]{rootnode}}, \code{\link[tidytree]{nodeid}}, \code{\link[tidytree]{nodelab}}, \code{\link[tidytree]{MRCA}}}
 }}
 

--- a/man/root-method.Rd
+++ b/man/root-method.Rd
@@ -5,9 +5,11 @@
 \alias{root.treedata}
 \title{root}
 \usage{
-\method{root}{phylo}(phy, outgroup, node = NULL, resolve.root = TRUE, ...)
+\method{root}{phylo}(phy, outgroup, node = NULL, resolve.root = TRUE,
+  ...)
 
-\method{root}{treedata}(phy, outgroup, node = NULL, resolve.root = TRUE, ...)
+\method{root}{treedata}(phy, outgroup, node = NULL,
+  resolve.root = TRUE, ...)
 }
 \arguments{
 \item{phy}{tree object}

--- a/man/tree_subset.Rd
+++ b/man/tree_subset.Rd
@@ -6,32 +6,14 @@
 \alias{tree_subset.treedata}
 \title{Subset tree objects by related nodes}
 \usage{
-tree_subset(
-  tree,
-  node,
-  levels_back = 5,
-  group_node = TRUE,
-  group_name = "group",
-  root_edge = TRUE
-)
+tree_subset(tree, node, levels_back = 5, group_node = TRUE,
+  group_name = "group", root_edge = TRUE)
 
-\method{tree_subset}{phylo}(
-  tree,
-  node,
-  levels_back = 5,
-  group_node = TRUE,
-  group_name = "group",
-  root_edge = TRUE
-)
+\method{tree_subset}{phylo}(tree, node, levels_back = 5,
+  group_node = TRUE, group_name = "group", root_edge = TRUE)
 
-\method{tree_subset}{treedata}(
-  tree,
-  node,
-  levels_back = 5,
-  group_node = TRUE,
-  group_name = "group",
-  root_edge = TRUE
-)
+\method{tree_subset}{treedata}(tree, node, levels_back = 5,
+  group_node = TRUE, group_name = "group", root_edge = TRUE)
 }
 \arguments{
 \item{tree}{a tree object of class phylo}

--- a/man/write.beast.Rd
+++ b/man/write.beast.Rd
@@ -4,7 +4,8 @@
 \alias{write.beast}
 \title{write.beast}
 \usage{
-write.beast(treedata, file = "", translate = TRUE, tree.name = "UNTITLED")
+write.beast(treedata, file = "", translate = TRUE,
+  tree.name = "UNTITLED")
 }
 \arguments{
 \item{treedata}{\code{treedata} object}


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
phyloxml format file can contain multiple phylogeny and muliple attributes in child nodes.
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
for multiple phylogeny, the return value is a `multitreedata` class, next I will write a function in `ggtree` to visualize the class.
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
library(treeio)
example(read.phyloxml)
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

