### PR TITLE
remove NA node in read.nhx

### DIFF
--- a/R/nhx.R
+++ b/R/nhx.R
@@ -33,7 +33,7 @@ read.nhx <- function(file) {
     phylo2 <- read.tree(text = tree2)
     node <- match(nlab, sub(".+(X\\d+)$","\\1",
                             c(phylo2$tip.label, phylo2$node.label)))
-
+    node <- node[!is.na(node)]
     nhx.matches <- gregexpr(pattern, treetext)
 
     matches <- nhx.matches[[1]]


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
remove NA node in read.nhx
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
when some nodes of nhx tree are lacked, it will generate error, because the matched nodes might contain NA values.
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

```
library(ggtree)
library(treeio)
treetext = "(((((((((((((Pseudechis_porphyriacus:18.6[&&NHX:S=0.0],Pseudechis_australis:18.6[&&NHX:S=0.0])Node14:0[&&NHX:S=0.99858],Oxyuranus_scutellatus:18.6[&&NHX:S=0.0])Node13:9[&&NHX:S=0.0],(Notechis_scutatus:9.58011[&&NHX:S=0.0],Austrelaps_superbus:9.58011[&&NHX:S=0.0])Node15:18.0199[&&NHX:S=0.0])Node12:0[&&NHX:S=0.0],((Drysdalia_coronoides:16.8136[&&NHX:S=0.0],Tropidechis_carinatus:16.8136[&&NHX:S=0.0])Node17:3.58639[&&NHX:S=0.0],Demansia_vestigiata:20.4[&&NHX:S=1.01894])Node16:7.2[&&NHX:S=0.0])Node11:5.11006[&&NHX:S=0.9363],Bungarus_candidus:32.7101[&&NHX:S=0.0])Node10:2.28994[&&NHX:S=0.0],((Naja_kaouthia:13.6149[&&NHX:S=0.0],Naja_atra:13.6149[&&NHX:S=0.00018])Node19:21.3851[&&NHX:S=0.01668],Ophiophagus_hannah:35[&&NHX:S=0.0])Node18:0[&&NHX:S=0.22436])Node9:0[&&NHX:S=0.77398],Hydrophis_elegans:35[&&NHX:S=0.0])Node8:11.4[&&NHX:S=2.02488],Leioheterodon_madagascariensis:46.4[&&NHX:S=0.15232])Node7:4.99311[&&NHX:S=0.0],(((Trimorphodon_biscutatus:37.078[&&NHX:S=0.9997],Dispholidus_typus:37.078[&&NHX:S=0.3146])Node22:10.522[&&NHX:S=0.0],Thamnophis_sirtalis:47.6[&&NHX:S=0.40902])Node21:0[&&NHX:S=0.0],(Philodryas_olfersii:33.4144[&&NHX:S=0.0],Erythrolamprus_poecilogyrus:33.4144[&&NHX:S=0.92616])Node23:14.1856[&&NHX:S=0.9886])Node20:3.79311[&&NHX:S=0.0])Node6:2.64135[&&NHX:S=0.0],(Cerberus_rynchops:21.6599[&&NHX:S=0.0],Pseudoferania_polylepis:21.6599[&&NHX:S=0.0])Node24:32.3745[&&NHX:S=0.92132])Node5:7.70362[&&NHX:S=0.0],((((((((((((Crotalus_adamanteus:6.62685[&&NHX:S=0.01158],Crotalus_oreganus:6.62685[&&NHX:S=0.01308])Node36:1.30638[&&NHX:S=0.0],Crotalus_atrox:7.93323[&&NHX:S=0.0])Node35:2.78789[&&NHX:S=0.0],Crotalus_horridus:10.7211[&&NHX:S=0.00018])Node34:1.76023[&&NHX:S=0.0],Sistrurus_catenatus:12.4813[&&NHX:S=0.00018])Node33:4.48308[&&NHX:S=0.0],Agkistrodon_piscivorus:16.9644[&&NHX:S=0.0])Node32:1.83013[&&NHX:S=0.0],Gloydius_blomhoffii:18.7946[&&NHX:S=0.01244])Node31:4.71982[&&NHX:S=0.0],Cerrophidion_godmani:23.5144[&&NHX:S=0.0])Node30:5.00284[&&NHX:S=0.0],(Trimeresurus_gracilis:27.4244[&&NHX:S=1.9792],Trimeresurus_stejnegeri:27.4244[&&NHX:S=0.0])Node37:1.09278[&&NHX:S=0.0])Node29:0.997358[&&NHX:S=0.0],((Protobothrops_flavoviridis:11.4324[&&NHX:S=0.0],Protobothrops_jerdonii:11.4324[&&NHX:S=0.0])Node39:15.634[&&NHX:S=0.0],Bothriechis_schlegelii:27.0664[&&NHX:S=0.0])Node38:2.44818[&&NHX:S=0.0])Node28:9.28542[&&NHX:S=0.0],Deinagkistrodon_acutus:38.8[&&NHX:S=0.00554])Node27:0[&&NHX:S=0.99944],Azemiops_feae:38.8[&&NHX:S=0.0])Node26:3.44041[&&NHX:S=0.00434],(((Vipera_nikolskii:1.79421[&&NHX:S=0.0],Vipera_berus:1.79421[&&NHX:S=0.0])Node42:15.6876[&&NHX:S=0.0],Daboia_russelii:17.4818[&&NHX:S=0.00018])Node41:18.3836[&&NHX:S=0.00142],Atheris_nitschei:35.8654[&&NHX:S=0.00572])Node40:6.37503[&&NHX:S=0.01222])Node25:19.4977[&&NHX:S=0.7494])Node4:29.0619[&&NHX:S=1.01654],Python_sebae:90.8[&&NHX:S=0.2437])Node3:76.3242[&&NHX:S=1.56558],((((((Varanus_gouldii:9.51234[&&NHX:S=0.00018],Varanus_panoptes:9.51234[&&NHX:S=0.0])Node48:8.49911[&&NHX:S=0.0],Varanus_mertensi:18.0115[&&NHX:S=0.0])Node47:7.23287[&&NHX:S=0.0],Varanus_komodoensis:25.2443[&&NHX:S=0.00018])Node46:7.34712[&&NHX:S=0.02314],((Varanus_acanthurus:21.2387[&&NHX:S=0.386],Varanus_gilleni:21.2387[&&NHX:S=0.0])Node50:3.96576[&&NHX:S=0.00018],Varanus_scalaris:25.2045[&&NHX:S=0.0])Node49:7.38697[&&NHX:S=0.9833])Node45:98.543[&&NHX:S=1.09066],((Gerrhonotus_infernalis:61.5[&&NHX:S=0.71362],Celestus_haetianus:61.5[&&NHX:S=2.45308])Node52:43.0535[&&NHX:S=0.02242],(Heloderma_suspectum:21.6925[&&NHX:S=0.0],Heloderma_horridum:21.6925[&&NHX:S=0.0])Node53:82.861[&&NHX:S=0.38274])Node51:26.5809[&&NHX:S=0.0])Node44:34.0946[&&NHX:S=1.16122],Anolis_carolinensis:165.229[&&NHX:S=0.31326])Node43:1.89509[&&NHX:S=0.4398]);"
tr <- read.nhx(textConnection(treetext))
p <- ggtree(tr) +
     geom_tiplab(size=2) +
     geom_nodelab(size=2) +
     geom_text2(aes(label=S), size = 1.5, color = "red",nudge_y = 0.5, nudge_x=-2) +
     xlim(c(0,200)) +
     theme_tree2()
p
```
![test](https://user-images.githubusercontent.com/17870644/99612558-c5402e00-2a50-11eb-8c5d-0600479e989c.png)

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

