### PR TITLE
fix a bug in read.tree() when a special newick file is used

### DIFF
--- a/R/newick.R
+++ b/R/newick.R
@@ -4,13 +4,15 @@
 ##' @title read.newick
 ##' @param file newick file
 ##' @param node.label parse node label as 'label' or 'support' value
-##' @param ... additional parameter, passed to 'read.tree'
+##' @param ... additional parameter, passed to 'scan()'
 ##' @return phylo or treedata object
 ##' @export
 ##' @author Guangchuang Yu
 read.newick <- function(file, node.label = "label", ...) {
     node.label <- match.arg(node.label, c("support", "label"))
-    tree <- read.tree(file, ...)
+    tree_data <- scan(file = file, what = "", sep = "\n", quiet = TRUE, ...)
+    tree_data <- paste0(tree_data, collapse = "")
+    tree <- read.tree(text = tree_data)
     if (node.label == "label")
         return(tree)
 


### PR DESCRIPTION
When I use `read.tree()` to read the a newick file provided by 'The All-Species Living Tree' Project, it fails to get the right tip.label.

```r
file <- "https://www.arb-silva.de/fileadmin/silva_databases/living_tree/LTP_release_123/LSU_release_02_2017/LTPs123_LSU_tree.newick"
read.tree(file, skip = 11)
```

This newick is supplied with multiple lines and quote tip label, and I further found these two special conditions lead to the error.

Here is a simple example.

```r
quote_tree <- "(('t2':0.04,
't1':0.34
):0.89,
('t5':0.37,
('t4':0.03,
't3':0.67):
0.9):
0.59)
; "
writeLines(quote_tree, "quote_tree.newick")
read.tree(file = "quote_tree.newick")
```

```
## 
## Phylogenetic tree with 5 tips and 4 internal nodes.
## 
## Tip labels:
##   t2, t2, t2, t2, t2
## 
## Rooted; includes branch lengths.
```

After digestion, I found the error may come from the internal function `single_quotes()` in `ape::read_tree()` function.
However, `read.tree()` works fine with one line newick files. Therefore, I just fix this issue directly by collapse the content.

Maybe it is more reasonable to create a PR in `ape`, but this is a quick fix so far.
