### PR TITLE
fix root method for treedata

### DIFF
--- a/R/method-reroot.R
+++ b/R/method-reroot.R
@@ -19,7 +19,9 @@ reroot_node_mapping <- function(tree, tree2){
 ##' @param phy tree object
 ##' @param outgroup a vector of mode numeric or character specifying the new outgroup
 ##' @param node node to reroot
-##' @param resolve.root a logical specifying whether to resolve the new root as a bifurcating node
+##' @param edgelabel a logical value specifying whether to treat node labels as 
+##' edge labels and thus eventually switching them so that they are associated 
+##' with the correct edges.
 ##' @param ... additional parameters passed to ape::root.phylo
 ##' @return rerooted tree
 ##' @importFrom ape root
@@ -27,9 +29,9 @@ reroot_node_mapping <- function(tree, tree2){
 ##' @export
 ##' @author Guangchuang Yu
 
-root.phylo <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...){
+root.phylo <- function(phy, outgroup, node = NULL, edgelabel = TRUE, ...){
     tree <- ape::root.phylo(phy, outgroup = outgroup, node = node,
-                            resolve.root = resolve.root, ...)
+                            edgelabel = edgelabel, ...)
 
     attr(tree, "reroot") <- TRUE
     node_map <- reroot_node_mapping(phy, tree)
@@ -42,9 +44,9 @@ root.phylo <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...){
 ##' @method root treedata
 ##' @export
 
-root.treedata <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...){
+root.treedata <- function(phy, outgroup, node = NULL, edgelabel = TRUE, ...){
     ## warning message
-    message("The use of this method may cause some node data missing (e.g. bootstrap values).")
+    message("The use of this method may cause some node data missing or incorrect (e.g. bootstrap values) if edgelabel is FALSE.")
     object <- phy
     # generate node old label and new label map table.
     node2label <- as_tibble(object@phylo) %>%
@@ -58,7 +60,7 @@ root.treedata <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...){
     
     # reroot tree
     tree <- root(tree, outgroup = outgroup, node = node,
-                 resolve.root = resolve.root, ...)
+                 edgelabel = edgelabel, ...)
     n.tips <- Ntip(tree)
     node_map<- attr(tree, "node_map") 
     

--- a/R/method-reroot.R
+++ b/R/method-reroot.R
@@ -1,42 +1,19 @@
-reroot_node_mapping <- function(tree, tree2) {
-    root <- rootnode(tree)
-
-    node_map <- data.frame(from=1:getNodeNum(tree), to=NA, visited=FALSE)
-    node_map[1:Ntip(tree), 2] <- match(tree$tip.label, tree2$tip.label)
-    node_map[1:Ntip(tree), 3] <- TRUE
-
-    node_map[root, 2] <- root
-    node_map[root, 3] <- TRUE
-
-    node <- rev(tree$edge[,2])
-    for (k in node) {
-        ##ip <- getParent(tree, k)
-        ip <- parent(tree, k)
-        if (node_map[ip, "visited"])
-            next
-
-        ## cc <- getChild(tree, ip)
-        cc <- child(tree, ip)
-        node2 <- node_map[cc,2]
-        if (anyNA(node2)) {
-            node <- c(node, k)
-            next
-        }
-
-        ## to <- unique(sapply(node2, getParent, tr=tree2))
-        to <- unique(sapply(node2, parent, .data=tree2))
-        to <- to[! to %in% node_map[,2]]
-        node_map[ip, 2] <- to
-        node_map[ip, 3] <- TRUE
-    }
-    node_map <- node_map[, -3]
+reroot_node_mapping <- function(tree, tree2){
+    treelab1 <- tree %>% 
+                as_tibble() %>%
+                dplyr::select(c("node", "label"))
+    treelab2 <- tree2 %>% 
+                as_tibble() %>%
+                dplyr::select(c("node", "label"))
+    node_map <- dplyr::inner_join(treelab1, treelab2, by="label") %>%
+                dplyr::select(c("node.x", "node.y")) %>%
+                dplyr::rename(c(from=.data$node.x, to=.data$node.y))
     return(node_map)
 }
 
-
 ##' re-root a tree
 ##'
-##' 
+##'
 ##' @title root
 ##' @rdname root-method
 ##' @param phy tree object
@@ -49,23 +26,10 @@ reroot_node_mapping <- function(tree, tree2) {
 ##' @method root phylo
 ##' @export
 ##' @author Guangchuang Yu
-root.phylo <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...) {
-    ## pos <- 0.5* object$edge.length[which(object$edge[,2] == node)]
-    
-    ## @importFrom phytools reroot
-    ## phytools <- "phytools"
-    ## require(phytools, character.only = TRUE, quietly = TRUE)
-    
-    ## phytools_reroot <- eval(parse(text="phytools::reroot"))
-    
-    ## tree <- phytools_reroot(object, node, pos)
 
-    tree <- ape::root.phylo(phy, outgroup = outgroup,
-                            node = node, resolve.root = resolve.root, ...)
-
-    if (Nnode(tree) != Nnode(phy)) {
-        return(tree)
-    }
+root.phylo <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...){
+    tree <- ape::root.phylo(phy, outgroup = outgroup, node = node,
+                            resolve.root = resolve.root, ...)
 
     attr(tree, "reroot") <- TRUE
     node_map <- reroot_node_mapping(phy, tree)
@@ -77,58 +41,205 @@ root.phylo <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...) {
 ##' @rdname root-method
 ##' @method root treedata
 ##' @export
-root.treedata <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...) {
+
+root.treedata <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...){
     ## warning message
-    message("The use of this method may cause some node data to become incorrect (e.g. bootstrap values).")
-
+    message("The use of this method may cause some node data missing (e.g. bootstrap values).")
     object <- phy
-    newobject <- object
-
-    ## ensure nodes/tips have a label to properly map @anc_seq/@tip_seq
+    # generate node old label and new label map table.
+    node2label <- as_tibble(object@phylo) %>%
+                  dplyr::select(c("node", "label"))
     tree <- object@phylo
-    if (is.null(tree$tip.label)) {
-        tree$tip.label <- as.character(1:Ntip(tree))
-    }
-    if (is.null(tree$node.label)) {
-        tree$node.label <- as.character((1:tree$Nnode) + Ntip(tree))
-    }
+    tree$tip.label <- paste0("t", seq_len(Ntip(tree)))
+    tree$node.label <- paste0("n", seq_len(Nnode(tree)))
+    node2label2 <- as_tibble(tree) %>%
+                  dplyr::select(c("node", "label"))
+    node2oldnewlab <- dplyr::inner_join(node2label, node2label2, by="node")
     
-    ## reroot tree
+    # reroot tree
     tree <- root(tree, outgroup = outgroup, node = node,
                  resolve.root = resolve.root, ...)
-    newobject@phylo <- tree
-
-    ## update node numbers in data
     n.tips <- Ntip(tree)
-    node_map<- attr(tree, "node_map")
-
-    if (is.null(node_map)) {
-        message("fail to assign associated data to rooted tree, only return tree structure (a phylo object)")
-        if (!resolve.root) {
-            message("maybe you can try again with `resolve.root = TRUE`")
-        }
-        return(tree)
-    }
-
+    node_map<- attr(tree, "node_map") 
+    
+    # replace new label with old label
+    treeda <- as_tibble(tree)
+    treeda1 <- treeda %>% 
+               dplyr::filter(.data$label %in% node2oldnewlab$label.y)
+    treeda2 <- treeda %>%
+               dplyr::filter(!(.data$label %in% node2oldnewlab$label.y))
+    # original label
+    treeda1$label <- node2oldnewlab[match(treeda1$label, node2oldnewlab$label.y), "label.x"] %>%
+                     unlist(use.names=FALSE)
+    treeda <- rbind(treeda1, treeda2)
+    tree <- treeda[order(treeda$node),] %>% as.phylo()
+    object@phylo <- tree
+    # update data or extraInfo function
     update_data <- function(data, node_map) {
-        newdata <- data
-        newdata[match(node_map$from, data$node), 'node'] <- node_map$to
-        
-                                        # clear root data
-        root <- newdata$node == (n.tips + 1)
-        newdata[root,] <- NA
-        newdata[root,'node'] <- n.tips + 1
-        
-        return(newdata)
+        cn <- colnames(data)
+        cn <- cn[cn != "node"]
+        data <- dplyr::inner_join(data, node_map, by=c("node"="from")) %>%
+                dplyr::select(c("to", cn)) %>% 
+                dplyr::rename(node=.data$to)
+
+        # clear root data
+        root <- data$node == (n.tips + 1)
+        data[root,] <- NA
+        data[root,'node'] <- n.tips + 1
+        return(data)
     }
-    
-    if (nrow(newobject@data) > 0) {
-        newobject@data <- update_data(object@data, node_map)
+    if (nrow(object@data) > 0) {
+        object@data <- update_data(object@data, node_map)
+    }    
+    if (nrow(object@extraInfo) > 0){
+        object@extraInfo <- update_data(object@extraInfo, node_map)
     }
-    
-    if (nrow(object@extraInfo) > 0) {
-        newobject@extraInfo <- update_data(object@extraInfo, node_map)
-    }
-    
-    return(newobject)
+
+    return(object)
 }
+
+
+## reroot_node_mapping <- function(tree, tree2) {
+##     root <- rootnode(tree)
+## 
+## 
+##     node_map <- data.frame(from=1:getNodeNum(tree), to=NA, visited=FALSE)
+##     node_map[1:Ntip(tree), 2] <- match(tree$tip.label, tree2$tip.label)
+##     node_map[1:Ntip(tree), 3] <- TRUE
+## 
+##     node_map[root, 2] <- root
+##     node_map[root, 3] <- TRUE
+## 
+##     node <- rev(tree$edge[,2])
+##     for (k in node) {
+##         ##ip <- getParent(tree, k)
+##         ip <- parent(tree, k)
+##         if (node_map[ip, "visited"])
+##             next
+## 
+##         ## cc <- getChild(tree, ip)
+##         cc <- child(tree, ip)
+##         node2 <- node_map[cc,2]
+##         if (anyNA(node2)) {
+##             node <- c(node, k)
+##             next
+##         }
+## 
+##         ## to <- unique(sapply(node2, getParent, tr=tree2))
+##         to <- unique(sapply(node2, parent, .data=tree2))
+##         to <- to[! to %in% node_map[,2]]
+##         node_map[ip, 2] <- to
+##         node_map[ip, 3] <- TRUE
+##     }
+##     node_map <- node_map[, -3]
+##     return(node_map)
+## }
+## 
+## 
+## ##' re-root a tree
+## ##'
+## ##' 
+## ##' @title root
+## ##' @rdname root-method
+## ##' @param phy tree object
+## ##' @param outgroup a vector of mode numeric or character specifying the new outgroup
+## ##' @param node node to reroot
+## ##' @param resolve.root a logical specifying whether to resolve the new root as a bifurcating node
+## ##' @param ... additional parameters passed to ape::root.phylo
+## ##' @return rerooted tree
+## ##' @importFrom ape root
+## ##' @method root phylo
+## ##' @export
+## ##' @author Guangchuang Yu
+## root.phylo <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...) {
+##     ## pos <- 0.5* object$edge.length[which(object$edge[,2] == node)]
+##     
+##     ## @importFrom phytools reroot
+##     ## phytools <- "phytools"
+##     ## require(phytools, character.only = TRUE, quietly = TRUE)
+##     
+##     ## phytools_reroot <- eval(parse(text="phytools::reroot"))
+##     
+##     ## tree <- phytools_reroot(object, node, pos)
+## 
+##     tree <- ape::root.phylo(phy, outgroup = outgroup,
+##                             node = node, resolve.root = resolve.root, ...)
+## 
+##     #if (Nnode(tree) != Nnode(phy)) {
+##     #    return(tree)
+##     #}
+## 
+##     attr(tree, "reroot") <- TRUE
+##     node_map <- reroot_node_mapping(phy, tree)
+##     attr(tree, "node_map") <- node_map
+##     return(tree)
+## }
+## 
+## 
+## ##' @rdname root-method
+## ##' @method root treedata
+## ##' @export
+## root.treedata <- function(phy, outgroup, node = NULL, resolve.root = TRUE, ...) {
+##     ## warning message
+##     message("The use of this method may cause some node data to become incorrect (e.g. bootstrap values).")
+## 
+##     object <- phy
+##     newobject <- object
+## 
+##     ## ensure nodes/tips have a label to properly map @anc_seq/@tip_seq
+##     tree <- object@phylo
+##     if (is.null(tree$tip.label)) {
+##         tree$tip.label <- as.character(1:Ntip(tree))
+##     }
+##     if (is.null(tree$node.label)) {
+##         #tree$node.label <- as.character((1:tree$Nnode) + Ntip(tree))
+##         tree$node.label <- paste0("node",1:Nnode(tree))
+##     }
+##     
+##     ## reroot tree
+##     tree <- root(tree, outgroup = outgroup, node = node,
+##                  resolve.root = resolve.root, ...)
+##     newobject@phylo <- tree
+## 
+##     ## update node numbers in data
+##     n.tips <- Ntip(tree)
+##     node_map<- attr(tree, "node_map")
+##     if (is.null(node_map)) {
+##         message("fail to assign associated data to rooted tree, only return tree structure (a phylo object)")
+##         if (!resolve.root) {
+##             message("maybe you can try again with `resolve.root = TRUE`")
+##         }
+##         return(tree)
+##     }
+## 
+##     update_data <- function(data, node_map) {
+##         newdata <- data
+##         
+##         indx <- match(node_map$from, data$node)
+##         indx <- indx[!is.na(indx)]
+##         
+##         indy <- match(data$node, node_map$from)
+##         indy <- indy[!is.na(indy)]
+##         
+##         newdata[indx, "node"] <- node_map[indy, "to"]
+##         
+##         # newdata[match(node_map$from, data$node), 'node'] <- node_map$to
+## 
+##         # clear root data
+##         root <- newdata$node == (n.tips + 1)
+##         newdata[root,] <- NA
+##         newdata[root,'node'] <- n.tips + 1
+##         
+##         return(newdata)
+##     }
+##     
+##     if (nrow(newobject@data) > 0) {
+##         newobject@data <- update_data(object@data, node_map)
+##     }
+##     
+##     if (nrow(object@extraInfo) > 0) {
+##         newobject@extraInfo <- update_data(object@extraInfo, node_map)
+##     }
+##     
+##     return(newobject)
+## }

--- a/R/method-reroot.R
+++ b/R/method-reroot.R
@@ -45,8 +45,10 @@ root.phylo <- function(phy, outgroup, node = NULL, edgelabel = TRUE, ...){
 ##' @export
 
 root.treedata <- function(phy, outgroup, node = NULL, edgelabel = TRUE, ...){
+    if (!edgelabel){
     ## warning message
-    message("The use of this method may cause some node data missing or incorrect (e.g. bootstrap values) if edgelabel is FALSE.")
+        message("The use of this method may cause some node data to become incorrect (e.g. bootstrap values) if 'edgelabel' is FALSE.")
+    }
     object <- phy
     # generate node old label and new label map table.
     node2label <- as_tibble(object@phylo) %>%

--- a/man/root-method.Rd
+++ b/man/root-method.Rd
@@ -5,9 +5,9 @@
 \alias{root.treedata}
 \title{root}
 \usage{
-\method{root}{phylo}(phy, outgroup, node = NULL, resolve.root = TRUE, ...)
+\method{root}{phylo}(phy, outgroup, node = NULL, edgelabel = TRUE, ...)
 
-\method{root}{treedata}(phy, outgroup, node = NULL, resolve.root = TRUE, ...)
+\method{root}{treedata}(phy, outgroup, node = NULL, edgelabel = TRUE, ...)
 }
 \arguments{
 \item{phy}{tree object}
@@ -16,7 +16,9 @@
 
 \item{node}{node to reroot}
 
-\item{resolve.root}{a logical specifying whether to resolve the new root as a bifurcating node}
+\item{edgelabel}{a logical value specifying whether to treat node labels as 
+edge labels and thus eventually switching them so that they are associated 
+with the correct edges.}
 
 \item{...}{additional parameters passed to ape::root.phylo}
 }


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
root method for treedata
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
after root treedata object, some data or extraInfo might be missed, or some node data might be incorrect.
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
library(treeio)
library(tidytree)

set.seed(1024)
tree <- rtree(30)

tree$node.label <- paste0("node", seq_len(Nnode(tree)))
# original phylo to tbl_tree
as_tibble(tree) %>% data.frame()
d <- data.frame(label=paste0("node", seq_len(Nnode(tree))), trait=seq_len(Nnode(tree)))
tree2 <- ape::root(tree, node=42, edgelabel=TRUE)
#print("$$$$$$$$$$$$$$$$$$$$$$$$$")
# after reroot phylo to tbl_tree
as_tibble(tree2) %>% data.frame()
tr <- full_join(as_tibble(tree), d, by = 'label') %>% as.treedata
# original treedata to tbl_tree
tr2 <- root(tr, node=42, edgelabel=TRUE)
as_tibble(tr) %>% dplyr::select(c("label", "trait")) %>% data.frame()
#print("#################")
# after reroot treedata to tbl_tree
as_tibble(tr2) %>% dplyr::select(c("label", "trait")) %>% data.frame()
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

I test original phylo and treedata. for phylo, after root, some node has been changed, some node label has been missed ('node1', 'node2' in this example), so I add data to the same phylo, then root it. the node data is consitent with original node data, except "node1" and "node2".