### PR TITLE
update method to parse phyloxml format file

### DIFF
--- a/R/phyloxml.R
+++ b/R/phyloxml.R
@@ -45,9 +45,11 @@ single_tree <- function(i, phylogeny, file){
     }
     dt <- dplyr::mutate(dt, label = as.character(dt$NodeID))
     dd <- as.phylo(edgedf, "branch_length")
-    # check whether if rooted tree
+    # check whether is rooted tree
     if (rootflag == "false"){
-        dd <- ape::unroot(dd)
+        if (ape::is.rooted(dd)){
+            dd <- ape::unroot(dd)
+        }
     }
     dd <- dd %>% as_tibble() %>%
             dplyr::full_join(dt, by='label')

--- a/R/phyloxml.R
+++ b/R/phyloxml.R
@@ -1,14 +1,14 @@
 #' @title read.phyloxml
 #' @param file phyloxml file
-#' @return treedata class or multitreedata class
+#' @return treedata class or treedataList class
 #' @export
 #' @examples
-#' xmlfile <- system.file("extdata/phyloxml", "test_x2.xml", package="treeio")
-#' px <- read.phyloxml(xmlfile)
-#' px
+#' xmlfile1 <- system.file("extdata/phyloxml", "test_x2.xml", package="treeio")
+#' px1 <- read.phyloxml(xmlfile1)
+#' px1
 #' xmlfile2 <- system.file("extdata/phyloxml", "phyloxml_examples.xml", package="treeio")
 #' px2 <- read.phyloxml(xmlfile2)
-#' class(px2)
+#' px2
 read.phyloxml <- function(file){
     x <- xml2::read_xml(file)
     x <- xml2::as_list(x)
@@ -18,46 +18,59 @@ read.phyloxml <- function(file){
         stop("The input file is not phyloxml format, please check it !")
     }
     if (length(index)==1){
-        obj <- single_tree(x[[index]], file)
+        objtmp <- single_tree(index, x, file)
+        obj <- objtmp[[1]]
     }else{
-        obj <- lapply(x[index], single_tree, file)
+        objtmp <- lapply(index, single_tree, x, file)
+        obj <- lapply(objtmp, function(x)x[[1]])
+        names(obj) <- unlist(lapply(objtmp, function(x)x[[2]]))
         class(obj) <- "treedataList"
     }
     return(obj)
 }
 
 #' @keywords internal
-single_tree <- function(phylogeny, file){
-    dt <- parser_clade(phylogeny[["clade"]])
+single_tree <- function(i, phylogeny, file){
+    rootflag <- unname(check_attrs(phylogeny[[i]]))
+    treename <- extract_treename(i, phylogeny)
+    dt <- parser_clade(phylogeny[[i]][["clade"]])
     dt <- dt[!is.na(dt$parentID), ]
-    if ("branch_length" %in% colnames(dt)){
+    if ("branch_length" %in% colnames(dt) & !all(is.na(dt[["branch_length"]]))){
         edgedf <- dt[,c("parentID", "NodeID", "branch_length")]
-        rmclumn <- c("parentID", "branch_length")
+        edgedf[(edgedf[,1]!=edgedf[,2] & is.na(edgedf[["branch_length"]])),"branch_length"] <- 0
+        rmclumn <- c("parentID", "NodeID", "branch_length")
     }else{
         edgedf <- dt[,c("parentID", "NodeID")]
-        rmclumn <- c("parentID")
+        rmclumn <- c("parentID", "NodeID")
     }
     dt <- dplyr::mutate(dt, label = as.character(dt$NodeID))
-    dd <- as.phylo(edgedf, "branch_length") %>% as_tibble() %>%
-            dplyr::full_join(dt, by='label')
-    if ("accession" %in% colnames(dd)){
-        dd$label <- as.vector(dd$accession)
-    }else{
-        if ("name" %in% colnames(dd)){
-            dd$label <- as.vector(dd$name)
-        }
-        if ( "scientific_name" %in% colnames(dd) & !"name"%in%colnames(dd)){
-            dd$label <- as.vector(dd$scientific_name)
-	}
+    dd <- as.phylo(edgedf, "branch_length")
+    # check whether if rooted tree
+    if (rootflag == "false"){
+        dd <- ape::unroot(dd)
     }
-    obj <- dd %>% dplyr::select(-rmclumn) %>% as.treedata
+    dd <- dd %>% as_tibble() %>%
+            dplyr::full_join(dt, by='label')
+    colnm <- colnames(dd)
+    if ("accession" %in% colnm){
+        dd$label <- as.vector(dd[["accession"]])
+        rmclumn <- c(rmclumn, "accession")
+    }else if ("scientific_name" %in% colnm && !"accession" %in% colnm){
+        dd$label <- as.vector(dd[["scientific_name"]])
+        rmclumn <- c(rmclumn, "scientific_name")
+    }else if ("name" %in% colnm && !"accession" %in% colnm && !"scientific_name" %in% colnm){
+        dd$label <- as.vector(dd[["name"]])
+        rmclumn <- c(rmclumn, "name")
+    }
+    obj <- dd %>% dplyr::select(-dplyr::all_of(rmclumn)) %>% as.treedata()
     obj@file <- filename(file)
-    return(obj)
+    return(c(obj, treename))
 }
 
 
 #' @keywords internal
 parser_clade <- function(x, id=list2env(list(id = 0L)), parent=NULL){
+    # to generate edge data
     id[["id"]] <- id[["id"]] + 1L
     id[["data"]][[id[["id"]]]] <- extract_values_attrs(x, id=id[["id"]], isTip=FALSE, parent=fill_id(parent))
     index <- which(names(x)=="clade")
@@ -83,23 +96,25 @@ fill_id <- function(x){
 extract_another <- function(x){
     namestmp <- names(x)
     index <- which(namestmp != "clade")
-    namestmp <- namestmp[index]
-    namestmp2 <- namestmp
-    dind <- which(duplicated(namestmp2)|duplicated(namestmp2, fromLast=TRUE))
-    if (length(dind)){
-        namestmp2 <- mapply(paste0, namestmp2[dind], 
-                            seq_len(length(dind)), SIMPLIFY=FALSE)
-    }
-    if (length(index)){
-        lapply(index, function(i){
-                      attrs <- check_attrs(x[[i]])
-                      values <- check_value(x[[i]])
-                      if (length(values)!=0 & length(names(values))==0){
-                          names(values) <- namestmp2[i]
-                      }
-                      c(values, attrs)
+    if (length(index) >0){
+        lapply(x[index], function(i){
+               attrs1 <- check_attrs(i)
+               attrs2 <- extract_attrs(i)
+               attrs <- c(attrs1, attrs2)
+               values <- check_value(i)
+               if(inherits(attrs, "list")){attrs <- remove_names(attrs)}
+               if(inherits(values,"list")){values <- remove_names(values)}
+               res <- unlist(c(attrs, values))
+               res <- res[!duplicated(res)]
+               namestmp2 <- names(res)
+               # rename the duplicated names
+               dind <- which(duplicated(namestmp2)|duplicated(namestmp2, fromLast=TRUE))
+               if (length(dind) & length(unique(res[dind]))>1){
+                   namestmp2[dind] <- unlist(mapply(paste0, namestmp2[dind],seq_len(length(dind)), SIMPLIFY=FALSE))
+               }
+               names(res) <- unlist(namestmp2)
+               return(res)
               })
-    
     }
 }
 
@@ -114,30 +129,64 @@ check_attrs <- function(x){
 
 #' @keywords internal
 check_value <- function(x){
-    if (inherits(x, "list")){
+    if(length(unlist(x))>1){
         lapply(x, check_value)
     }else{
-        if(length(x)>2){
-            lapply(x, check_value)
-	}else{
-            list(check_attrs(x), unlist(x))
+        if (length(unlist(x))==0){
+            return(c(check_attrs(x)))
+        }else{
+            return(c(check_attrs(x), remove_names(x)))
         }
     }
 }
 
+extract_attrs <- function(x){
+    lapply(x, check_attrs)
+}
+
+#' @keywords internal
+extract_treename <- function(i, phylogeny){
+    if ("name" %in% names(phylogeny[[i]])){
+        treename <- unlist(phylogeny[[i]][["name"]])
+    }else{
+        treename <- paste0("phylogeny_", i)
+    }
+    return (treename)
+}
+
+remove_names <- function(x){
+    for (i in seq_len(length(x))){
+        if (!is.null(x[[i]])){
+            if (is.null(names(x[[i]])) && !is.null(x[[i]])){
+                names(x[[i]]) <- names(x[i])
+            }else{
+                names(x[[i]])[nchar(names(x[[i]]))==0] <- names(x[i])
+            }
+        }
+    }
+    names(x) <- NULL
+    return(x)
+}
+
+
 #' @keywords internal
 extract_values_attrs <- function(x, id, parent, isTip){
+    # extract attributes of x to avoid them being remove in lapply.
     attr <- check_attrs(x)
-    anothers <- unlist(extract_another(x))
+    anothers <- extract_another(x)
+    anothers <- unlist(remove_names(anothers))
     res <- c(attr, anothers)
     if (!is.null(res)){
-       res <- data.frame(t(res), check.names=FALSE, stringsAsFactors=FALSE)
-       res$parentID <- parent
-       res$NodeID <- id
-       res$isTip <- isTip
+        res <- data.frame(t(res), check.names=FALSE, stringsAsFactors=FALSE)
+        res$parentID <- parent
+        res$NodeID <- id
+        res$isTip <- isTip
     }else{
-       res <- data.frame(parentID=parent, NodeID=id, isTip=isTip,
-                         check.names=FALSE, stringsAsFactors=FALSE)
+        res <- data.frame(parentID=parent, NodeID=id, isTip=isTip,
+                          check.names=FALSE, stringsAsFactors=FALSE)
+    }
+    if ("confidence" %in% colnames(res)){
+        res$confidence <- as.numeric(res$confidence)
     }
     return(res)
 }

--- a/man/read.phyloxml.Rd
+++ b/man/read.phyloxml.Rd
@@ -10,16 +10,16 @@ read.phyloxml(file)
 \item{file}{phyloxml file}
 }
 \value{
-treedata class or multitreedata class
+treedata class or treedataList class
 }
 \description{
 read.phyloxml
 }
 \examples{
-xmlfile <- system.file("extdata/phyloxml", "test_x2.xml", package="treeio")
-px <- read.phyloxml(xmlfile)
-px
+xmlfile1 <- system.file("extdata/phyloxml", "test_x2.xml", package="treeio")
+px1 <- read.phyloxml(xmlfile1)
+px1
 xmlfile2 <- system.file("extdata/phyloxml", "phyloxml_examples.xml", package="treeio")
 px2 <- read.phyloxml(xmlfile2)
-class(px2)
+px2
 }

--- a/tests/testthat/test-phyloxml.R
+++ b/tests/testthat/test-phyloxml.R
@@ -1,0 +1,23 @@
+context("phyloxml input")
+
+library(treeio)
+xmlfile1 <- system.file("extdata/phyloxml", "test_x2.xml", package="treeio")
+xmlfile2 <- system.file("extdata/phyloxml", "phyloxml_examples.xml", package="treeio")
+tx1 <- read.phyloxml(xmlfile1)
+tx2 <- read.phyloxml(xmlfile2)
+
+test_that("read.phyloxml should work for phyloxml",{
+    expect_true(is(tx1, "treedata"))
+    expect_true(is(tx2, "treedataList"))
+    expect_equal(length(tx2), 13)
+})
+
+dat <- list(A=list(a=12, b=c(B=1, "t")))
+res1 <- extract_another(dat)
+res2 <- list(A=c(a=12,B=1,b="t"))
+
+test_that("checking extract_another",{
+    expect_equal(res1, res2)
+})
+
+


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
update method to parse phyloxml format file
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
1. consider the unrooted or rooted tree
2. extract all asscoiated data, including the attri and values.
3. when a phyloxml file contains multiple phylogeny tree, it will return a treedataList, a list contained multiple treedata object.
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

```
> library(treeio)
Registered S3 method overwritten by 'treeio':
  method     from
  root.phylo ape
treeio v1.15.2  For help: https://yulab-smu.top/treedata-book/

If you use treeio in published research, please cite:

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package for phylogenetic tree input and output with richly annotated and associated data. Molecular Biology and Evolution 2020, 37(2):599-603. doi: 10.1093/molbev/msz240

> library(tidytree)
> example(read.phyloxml)

rd.phy> xmlfile1 <- system.file("extdata/phyloxml", "test_x2.xml", package="treeio")

rd.phy> px1 <- read.phyloxml(xmlfile1)

rd.phy> px1
'treedata' S4 object that stored information of
        '/mnt/d/UbuntuApps/R/4.0.3/lib/R/library/treeio/extdata/phyloxml/test_x2.xml'.

...@ phylo:
Phylogenetic tree with 10 tips and 9 internal nodes.

Tip labels:
  t7, t2, t3, t8, t1, t5, ...

Rooted; includes branch lengths.

with the following features available:
        ''.

rd.phy> xmlfile2 <- system.file("extdata/phyloxml", "phyloxml_examples.xml", package="treeio")

rd.phy> px2 <- read.phyloxml(xmlfile2)

rd.phy> px2
13 phylogenetic trees
> lapply(px2, function(x)head(data.frame(as_tibble(x))))
$`example from Prof. Joe Felsenstein's book "Inferring Phylogenies"`
  parent node branch.length label
1      5    1         0.102     A
2      5    2         0.230     B
3      4    3         0.400     C
4      4    4            NA  <NA>
5      4    5         0.060  <NA>

$`example from Prof. Joe Felsenstein's book "Inferring Phylogenies"`
  parent node branch.length label
1      5    1         0.102     A
2      5    2         0.230     B
3      4    3         0.400     C
4      4    4            NA  <NA>
5      4    5         0.060  <NA>

$`same example, with support of type "bootstrap"`
  parent node branch.length label      type confidence
1      5    1         0.102     A      <NA>         NA
2      5    2         0.230     B      <NA>         NA
3      4    3         0.400     C      <NA>         NA
4      4    4            NA  <NA>      <NA>         NA
5      4    5         0.060    AB bootstrap         89

$`same example, with species and sequence`
  parent node branch.length       label name                  desc
1      5    1            NA     E. coli    A alcohol dehydrogenase
2      5    2            NA B. subtilis    B alcohol dehydrogenase
3      4    3            NA  C. elegans    C alcohol dehydrogenase
4      4    4            NA        <NA> <NA>                  <NA>
5      4    5            NA        <NA>   AB                  <NA>
  confidence.type confidence
1     probability       0.99
2     probability       0.91
3     probability       0.67
4            <NA>         NA
5            <NA>         NA

$`same example, with gene duplication information and sequence relationships`
  parent node branch.length    label speciations duplications
1      5    1            NA AAB80874        <NA>         <NA>
2      5    2            NA CAB15083        <NA>         <NA>
3      4    3            NA   Q17335        <NA>         <NA>
4      4    4            NA     <NA>        <NA>         <NA>
5      4    5            NA     <NA>        <NA>            1
         scientific_name id_source source symbol                  name
1      Bacillus subtilis         x   ncbi   adhB alcohol dehydrogenase
2      Bacillus subtilis         y   ncbi   gbsB alcohol dehydrogenase
3 Caenorhabditis elegans         z   ncbi   ADHX alcohol dehydrogenase
4                   <NA>      <NA>   <NA>   <NA>                  <NA>
5                   <NA>      <NA>   <NA>   <NA>                  <NA>
                 ref
1               <NA>
2               <NA>
3 InterPro:IPR002085
4               <NA>
5               <NA>

$`similar example, with more detailed sequence data`
  parent node branch.length  label provider    id  code
1      5    1            NA P81431     NCBI  6645 OCTVU
2      5    2            NA Q54II4     NCBI 44689 DICDI
3      4    3            NA Q04945     NCBI  1488 CLOAB
4      4    4            NA   <NA>     <NA>  <NA>  <NA>
5      4    5            NA   <NA>     <NA>  <NA>  <NA>
             scientific_name    source       ref1
1           Octopus vulgaris UniProtKB EC:1.1.1.1
2   Dictyostelium discoideum UniProtKB GO:0008270
3 Clostridium acetobutylicum UniProtKB GO:0046872
4                       <NA>      <NA>       <NA>
5                       <NA>      <NA>       <NA>
                                ref2 symbol
1                         GO:0004022   ADHX
2                         GO:0016491  RT4I1
3 KEGG:Tetrachloroethene degradation   ADHB
4                               <NA>   <NA>
5                               <NA>   <NA>
                                                                name
1                                      Alcohol dehydrogenase class-3
2 Reticulon-4-interacting protein 1 homolog, mitochondrial precursor
3                             NADH-dependent butanol dehydrogenase B
4                                                               <NA>
5                                                               <NA>
                                             mol_seq
1 TDATGKPIKCMAAIAWEAKKPLSIEEVEVAPPKSGEVRIKILHSGVCHTD
2 MKGILLNGYGESLDLLEYKTDLPVPKPIKSQVLIKIHSTSINPLDNVMRK
3 MVDFEYSIPTRIFFGKDKINVLGRELKKYGSKVLIVYGGGSIKRNGIYDK
4                                               <NA>
5                                               <NA>

$`network, node B is connected to TWO nodes: AB and C`
  parent node branch.length label id_source
1      4    1         0.102     A         a
2      4    2         0.230     B         b
3      4    3         0.460     C         c
4      4    4            NA    AB        ab

$`same example, using property elements to indicate a "depth" value for marine organisms`
  parent node branch.length label    datatype        ref applies_to     unit
1      5    1            NA     A xsd:integer NOAA:depth      clade METRIC:m
2      5    2            NA     B xsd:integer NOAA:depth      clade METRIC:m
3      4    3            NA     C xsd:integer NOAA:depth      clade METRIC:m
4      4    4            NA  <NA>        <NA>       <NA>       <NA>     <NA>
5      4    5            NA    AB        <NA>       <NA>       <NA>     <NA>
  property
1    1200
2    2300
3     200
4     <NA>
5     <NA>

$`same example, using property elements to indicate a "depth" value for marine organisms by using id refs in\n         order to have property elements outside of the tree topology`
  parent node branch.length label id_source
1      5    1            NA     A      id_a
2      5    2            NA     B      id_b
3      4    3            NA     C      id_c
4      4    4            NA  <NA>      <NA>
5      4    5            NA    AB      <NA>

$`monitor lizards`
  parent node branch.length              label provider      desc     id
1      4    1            NA  Varanus niloticus     NCBI    Africa  62046
2      5    2            NA     Varanus storri     NCBI Australia 169855
3      5    3            NA Varanus timorensis     NCBI      Asia  62053
4      4    4            NA               <NA>     <NA>      <NA>   <NA>
5      4    5            NA            Odatria     <NA>      <NA>   <NA>
      rank  uri     common_name
1  species <NA>    Nile monitor
2  species <NA> Storr's monitor
3  species <NA>   Timor monitor
4     <NA> <NA>            <NA>
5 subgenus <NA>            <NA>

$`A tree with phylogeographic information`
  parent node branch.length label geodetic_datum alt_unit
1      6    1            NA     A          WGS84        m
2      6    2            NA     B          WGS84        m
3      6    3            NA     C          WGS84        m
4      5    4            NA     D          WGS84        m
5      5    5            NA  <NA>           <NA>     <NA>
6      5    6            NA  <NA>           <NA>     <NA>
                                desc       lat        long  alt
1 Hirschweg, Winterthur, Switzerland 47.481277    8.769303  472
2               Nagoya, Aichi, Japan 35.155904  136.915863   10
3                         ETH Zürich 47.376334    8.548108  452
4                          San Diego 32.880933 -117.217543  104
5                               <NA>      <NA>        <NA> <NA>
6                               <NA>      <NA>        <NA> <NA>

$`A tree with date information`
  parent node branch.length label unit      desc value minimum maximum
1      5    1            NA     A  mya  Silurian   425   416.0   443.7
2      5    2            NA     B  mya  Devonian   320    <NA>    <NA>
3      4    3            NA     C  mya Ediacaran   600    <NA>    <NA>
4      4    4            NA  <NA> <NA>      <NA>  <NA>    <NA>    <NA>
5      4    5            NA  <NA> <NA>      <NA>  <NA>    <NA>    <NA>

$`Using another XML language to store an alignment`
  parent node branch.length label
1      5    1            NA     A
2      5    2            NA     B
3      4    3            NA     C
4      4    4            NA  <NA>
5      4    5            NA  <NA>
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

