### PR TITLE
update read.beast

### DIFF
--- a/R/beast.R
+++ b/R/beast.R
@@ -192,18 +192,21 @@ read.stats_beast_internal <- function(beast, tree) {
     stats <- sub("^&", "", stats)
     stats <- sub("];*$", "", stats)
     stats <- gsub("\"", "", stats)
-    
+
     stats2 <- lapply(seq_along(stats), function(i) {
         x <- stats[[i]]
         y <- unlist(strsplit(x, ","))
-        # the stats information has not always {}
+        # the stats information does not has always {}
         #sidx <- grep("=\\{", y)
         #eidx <- grep("\\}$", y)
         # [&mutation="test1,test2",rate=80,90]
-        sidx <- grep("=", y)
-        eidx <- sidx - 1
-        eidx <- c(eidx[-1], length(y))
-
+        sidx1 <- grep("=", y)
+        eidx1 <- sidx1 - 1
+        eidx1 <- c(eidx1[-1], length(y))
+        # for better parsing [&mutation="test",name="A"] single value to key.
+        sidx <- sidx1[!(sidx1==eidx1)]
+        eidx <- eidx1[!(sidx1==eidx1)]
+        
         flag <- FALSE
         if (length(sidx) > 0) {
             flag <- TRUE

--- a/R/beast.R
+++ b/R/beast.R
@@ -212,7 +212,9 @@ read.stats_beast_internal <- function(beast, tree) {
             flag <- TRUE
             SETS <- lapply(seq_along(sidx), function(k) {
                 p <- y[sidx[k]:eidx[k]]
-                gsub(".*=\\{", "", p) %>% gsub("\\}$", "", .)
+                gsub(".*=\\{", "", p) %>% 
+                    gsub("\\}$", "", .) %>%
+                    gsub(".*=", "", .)
             })
             names(SETS) <- gsub("=.*", "", y[sidx])
 


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
the problem of nexus format file.
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
#47 
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
this file is different with the beast output file of example.
+ the statistical information is not after tip or node label, but after edge length. eg: `t1:0.02[&mutation="test1"]`
+ the statistical information contained multiple values did't `{}`. eg: `t2:0.04[&mutation="test1","test2"]`
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

```
> library(treeio)
Registered S3 method overwritten by 'treeio':
  method     from
  root.phylo ape
treeio v1.15.4  For help: https://yulab-smu.top/treedata-book/

If you use treeio in published research, please cite:

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package for phylogenetic tree input and output with richly annotated and associated data. Molecular Biology and Evolution 2020, 37(2):599-603. doi: 10.1093/molbev/msz240

> example(read.beast)

rd.bst> file <- system.file("extdata/BEAST", "beast_mcc.tree", package="treeio")

rd.bst> read.beast(file)
'treedata' S4 object that stored information of
        '/mnt/d/UbuntuApps/R/4.0.4/lib/R/library/treeio/extdata/BEAST/beast_mcc.tree'.

...@ phylo:
Phylogenetic tree with 15 tips and 14 internal nodes.

Tip labels:
  A_1995, B_1996, C_1995, D_1987, E_1996, F_1997, ...

Rooted; includes branch lengths.

with the following features available:
        'height',       'height_0.95_HPD',      'height_median',        'height_range', 'length',
        'length_0.95_HPD',      'length_median',        'length_range', 'posterior',    'rate',
        'rate_0.95_HPD',        'rate_median',  'rate_range'.
> tr <- read.beast("./treefile.nexus.txt")
> tr
'treedata' S4 object that stored information of
        './treefile.nexus.txt'.

...@ phylo:
Phylogenetic tree with 936 tips and 197 internal nodes.

Tip labels:
  Pingxiang/JX5/2020//EPI_ISL_421252/_000, Jiangxi/IVDC-JX-002/2020//EPI_ISL_4_001, 20200110302_2020-1-10_Wuhan_L, Wuhan/HB-WH4-197/2020//EPI_ISL_4549_002, YB20200116082_2020-1-16_Wuhan_L, 20200110425_2020-1-10_Wuhan_L, ...
Node labels:
  NODE_0000000, NODE_0000001, NODE_0000005, NODE_0000016, NODE_0000018, NODE_0000029, ...

Rooted; includes branch lengths.

with the following features available:
        'mutations'.
> tr@data
# A tibble: 674 x 2
   mutations  node
   <list>     <chr>
 1 <chr [1]>  938
 2 <chr [2]>  3
 3 <chr [1]>  4
 4 <chr [10]> 5
 5 <chr [1]>  6
 6 <chr [2]>  7
 7 <chr [1]>  939
 8 <chr [2]>  8
 9 <chr [2]>  9
10 <chr [2]>  10
# … with 664 more rows
>
```