### PR TITLE
fix read.beast

### DIFF
--- a/R/beast.R
+++ b/R/beast.R
@@ -185,11 +185,14 @@ read.stats_beast_internal <- function(beast, tree) {
    	tree <- gsub("\\]:\\[&(.+?\\])", ",\\1:", tree)
     # t1:[&mutation="test1"]0.04 -> t1[&mutation="test1"]:0.04
     tree <- gsub(":(\\[.+?\\])", "\\1:", tree)
-    # t1:0.04[&mutation="test1"] -> t1[&mutation="test1"]:0.04
-    # or t1[&prob=100]:0.04[&mutation="test"] -> t1[&prob=100][&mutation="test"]:0.04 (MrBayes output)
-    pattern <- "(\\w+)?(:?\\d*\\.?\\d*[Ee]?[\\+\\-]?\\d*)?(\\[&.*?\\])"
-    tree <- gsub(pattern, "\\1\\3\\2", tree)
-    
+
+    if (grepl("\\:[0-9\\.eE+\\-]*\\[", tree) || grepl("\\]\\[", tree)){
+        # t1:0.04[&mutation="test1"] -> t1[&mutation="test1"]:0.04
+        # or t1[&prob=100]:0.04[&mutation="test"] -> t1[&prob=100][&mutation="test"]:0.04 (MrBayes output)
+        # pattern <- "(\\w+)?(:?\\d*\\.?\\d*[Ee]?[\\+\\-]?\\d*)?(\\[&.*?\\])"
+        pattern <- "(\\w+)?(:\\d*\\.?\\d*[Ee]?[\\+\\-]?\\L*\\d*)?(\\[&.*?\\])"
+        tree <- gsub(pattern, "\\1\\3\\2", tree)
+    }
     #if (grepl("\\]:[0-9\\.eE+\\-]*\\[", tree) || grepl("\\]\\[", tree)) {
     #    ## MrBayes output
     #    stats <- strsplit(tree, "\\]:[0-9\\.eE+\\-]*\\[") %>% unlist

--- a/R/beast.R
+++ b/R/beast.R
@@ -186,7 +186,7 @@ read.stats_beast_internal <- function(beast, tree) {
     # t1:[&mutation="test1"]0.04 -> t1[&mutation="test1"]:0.04
     tree <- gsub(":(\\[.+?\\])", "\\1:", tree)
 
-    if (grepl("\\:[0-9\\.eE+\\-]*\\[", tree) || grepl("\\]\\[", tree)){
+    if (grepl("\\:[0-9\\.eEL+\\-]*\\[", tree) || grepl("\\]\\[", tree)){
         # t1:0.04[&mutation="test1"] -> t1[&mutation="test1"]:0.04
         # or t1[&prob=100]:0.04[&mutation="test"] -> t1[&prob=100][&mutation="test"]:0.04 (MrBayes output)
         # pattern <- "(\\w+)?(:?\\d*\\.?\\d*[Ee]?[\\+\\-]?\\d*)?(\\[&.*?\\])"

--- a/man/beast-parser.Rd
+++ b/man/beast-parser.Rd
@@ -31,6 +31,8 @@ read beast/mrbayes/mega newick file format
 \examples{
 file <- system.file("extdata/BEAST", "beast_mcc.tree", package="treeio")
 read.beast(file)
+file <- system.file("extdata/MrBayes", "Gq_nxs.tre", package="treeio")
+read.mrbayes(file)
 tree <- read.beast.newick(textConnection('(a[&rate=1]:2,(b[&rate=1.1]:1,c[&rate=0.9]:1)[&rate=1]:1);'))
 }
 \author{


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix read.beast, the following regular expression has a problem when the labels contain the `+` or `-` symbol.
```
> xx <- "SS+13[&mutation='test']:1e-10[&test=5],S-20[&mutation='A']:1e-5[&test=6],S+L[&mutation='B']:1L[&test=10]"
> pattern <- "(\\w+)?(:?\\d*\\.?\\d*[Ee]?[\\+\\-]?\\d*)?(\\[&.*?\\])"
> gsub(patter, "\\1\\3\\2", xx)
[1] "SS[&mutation='test']+13[&test=5]:1e-10,S[&mutation='A']-20[&test=6]:1e-5,S+L[&mutation='B']:1L[&test=10]"

```
I think when the statistic information is after the edge length, we might need to check it first. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #55 
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

```
> pattern2 <- "(\\w+)?(:\\d*\\.?\\d*[Ee]?[\\+\\-]?\\L*\\d*)?(\\[&.*?\\])"
> xx <- "SS+13[&mutation='test']:1e-10[&test=5],S-20[&mutation='A']:1e-5[&test=6],S+L[&mutation='B']:1L[&test=10]"
> gsub(pattern2, "\\1\\3\\2", xx)
[1] "SS+13[&mutation='test'][&test=5]:1e-10,S-20[&mutation='A'][&test=6]:1e-5,S+L[&mutation='B'][&test=10]:1L"
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

