### PR TITLE
to fix issues about additional parameters of drop.tip

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -124,3 +124,31 @@ has.slot <- function(object, slotName) {
     .hasSlot(object, slotName)
 }
 
+build_new_labels <- function(tree){
+    node2label_old <- tree %>% as_tibble() %>% dplyr::select(c("node", "label")) 
+    if (inherits(tree, "treedata")){
+        tree <- tree@phylo
+    }
+    tree$tip.label <- paste0("t", seq_len(Ntip(tree)))
+    tree$node.label <- paste0("n", seq_len(Nnode(tree)))
+    node2label_new <- tree %>% as_tibble() %>% dplyr::select(c("node", "label")) 
+    old_and_new <- node2label_old %>% 
+                   dplyr::inner_join(node2label_new, by="node") %>%
+                   dplyr::rename(old="label.x", new="label.y") 
+    return (list(tree=tree, node2old_new_lab=old_and_new))
+}
+
+build_new_tree <- function(tree, node2old_new_lab){
+    # replace new label with old label
+    treeda <- tree %>% as_tibble()
+    treeda1 <- treeda %>%
+               dplyr::filter(.data$label %in% node2old_new_lab$new)
+    treeda2 <- treeda %>%
+               dplyr::filter(!(.data$label %in% node2old_new_lab$new))
+    # original label
+    treeda1$label <- node2old_new_lab[match(treeda1$label, node2old_new_lab$new), "old"] %>%
+                     unlist(use.names=FALSE)
+    treeda <- rbind(treeda1, treeda2)
+    tree <- treeda[order(treeda$node),] %>% as.phylo() 
+    return (tree)
+}


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The additional parameters of `drop.tip` does not work. Thie request fixed the issues via the similar method of `root.treedata` #42 .

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #57 
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
library(treeio)
library(ggtree)
nhxfile <- system.file("extdata/NHX", "ADH.nhx", package="treeio")
nhx <- read.nhx(nhxfile)
tr1 <- drop.tip(nhx, c("ADH2", "ADH1"))
tr2 <- drop.tip(nhx, c("ADH2", "ADH1"), trim.internal=FALSE)
tr3 <- drop.tip(nhx, c("ADH2", "ADH1"), subtree=T)
tr4 <- drop.tip(nhx, c("ADH2", "ADH1"), trim.internal=FALSE, subtree=T)
p1 <- ggtree(tr1) + geom_tiplab()
p2 <- ggtree(tr2) + geom_tiplab()
p3 <- ggtree(tr3) + geom_tiplab()
p4 <- ggtree(tr4) + geom_tiplab()
p1/p2/p3/p4
```
![drop tip](https://user-images.githubusercontent.com/17870644/123041419-da869c00-d427-11eb-9e22-ec1c3ba6f82b.PNG)

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

