### PR TITLE
fix the add_pseudo_nodelabel when the node.label is not null in beast file 

### DIFF
--- a/tests/testthat/test-beast.R
+++ b/tests/testthat/test-beast.R
@@ -30,3 +30,19 @@ test_that("write.beast output a valid beast file", {
     expect_true(is(read.beast(beast_file), "treedata"))
 })
 
+
+xx <- "(a[&rate=1]:2,(b[&rate=1.1]:1,c[&rate=0.9]:1)[&rate=1]:1);\n(a[&rate=1]:2,(b[&rate=1.1]:1,c[&rate=0.9]:1)[&rate=1]:1);"
+
+tree1 <- structure(list(edge=matrix(c(4L, 4L, 5L, 5L, 1L, 5L, 2L, 3L), ncol=2),
+                        edge.length=c(2, 1, 1, 1),
+                        Nnode=2L,
+                        tip.label=c("a", "b", "c")),
+                        class="phylo",
+                        order="cladewise"
+                        )
+trees <- read.beast.newick(textConnection(xx))
+
+test_that("read.beast.newick should work for multiple trees",{
+    expect_true(inherits(trees, "treedataList"))
+    expect_equal(trees[[1]]@phylo, tree1)
+})


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the `node.label` of `beast` is not NULL, but contains the same character, such as "". The `read.beast` can not work well.
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
#63 request provided by @brj1 also illustrated the problem. But it can also resolve the problem. 
for example, when the `tip.label` contained the same name of `node.label` replaced by `add_pseudo_nodelabel`.

In fact, The `phylo` of `treedata` that obtained from `beast` file is parsed via `read.nexus`. And the statistic information is a tibble contained node number and other information, which is calculated by `temporary tree` belonged to the `tree lines` of `beast`. 
But some conditions should be considered.
 +   When `TRANSLATE` of `beast file` is TURE, the `tip.label` of `tree line` is the node number of `phylo` that is parsed via `read.nexus`, so the  `tip.label` can not be replaced in this condition in the `temporary tree`. Otherwise, the node number will be not correct.
 +   However, when the `TRANSLATE` is not provided, the `tip.label` of `tree line` is not the node number of `phylo` that is parsed via `read.nexus`. 
 +  Moreover, the node label does not affect the node number of `phylo` that is parsed via `read.nexus`. So the `node.label` can be replaced.

But when the `TRANSLATE` is not provided, it can no work well, when `tip.label` contains the same name of `node.label` replaced by `add_pseudo_nodelabel`. I think it is more robust to replace the `tip.label` in this condition.

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

```
> library(treeio)
treeio v1.17.2  For help: https://yulab-smu.top/treedata-book/

If you use treeio in published research, please cite:

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package for phylogenetic tree input and output with richly annotated and associated data. Molecular Biology and Evolution 2020, 37(2):599-603. doi: 10.1093/molbev/msz240

> xx <- '((1[&x="1"]:1,2[&x="2"]:1)5[&x="3"]:1,(3[&x="4"]:1,4[&x="5"]:1)[&x="6"]:1)[&x="7"];'
> trda <- read.beast.newick(textConnection(xx))
> trda %>% as_tibble()
# A tibble: 7 x 5
  parent  node branch.length label     x
   <int> <int>         <dbl> <chr> <dbl>
1      6     1             1 "1"       1
2      6     2             1 "2"       2
3      7     3             1 "3"       4
4      7     4             1 "4"       5
5      5     5            NA ""        7
6      5     6             1 "5"       3
7      5     7             1 ""        6
>
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

