### PR TITLE
fix drop.tip when all tips removed

### DIFF
--- a/R/method-drop-tip.R
+++ b/R/method-drop-tip.R
@@ -30,6 +30,10 @@ drop.tip.treedata <- function(object, tip, ...){
     params$phy <- tree
     params$tip <- tip
     new_tree <- do.call(ape::drop.tip, params)
+
+    if (is.null(new_tree)){
+        return(new_tree)
+    }
     
     trans_node_data <- old_new_node_mapping(tree, new_tree)
     object@phylo <- build_new_tree(tree=new_tree, node2old_new_lab=old_and_new)


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If all tips for treedata object are removed via `drop.tip`, it will generate an error.
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

