### PR TITLE
fix outgroup (character type) of root for treedata

### DIFF
--- a/R/method-reroot.R
+++ b/R/method-reroot.R
@@ -56,6 +56,9 @@ old_new_node_mapping <- function(oldtree, newtree){
 ##' @export
 
 root.treedata <- function(phy, outgroup, node = NULL, edgelabel = TRUE, ...){
+    if (is.character(outgroup)){
+        outgroup <- match(outgroup, phy@phylo$tip.label)
+    }
     if (!edgelabel){
     ## warning message
         message("The use of this method may cause some node data to become incorrect (e.g. bootstrap values) if 'edgelabel' is FALSE.")


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix the issue about the `outgroup` (character type) of root
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
because the `tip.label` of `tree` for the `root.treedata` method has bee replaced by the temporary labels. If the `outgroup` is from the tip label of original tree, this will generate error.
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
> library(treeio)
treeio v1.17.2  For help: https://yulab-smu.top/treedata-book/

If you use treeio in published research, please cite:

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package for phylogenetic tree input and output with richly annotated and associated data. Molecular Biology and Evolution 2020, 37(2):599-603. doi: 10.1093/molbev/msz240

> tr <- rtree(6)
> N <- Nnode(tr, internal.only=F)
> da <- data.frame(id=seq_len(N), value=seq_len(N)*2)
> da
   id value
1   1     2
2   2     4
3   3     6
4   4     8
5   5    10
6   6    12
7   7    14
8   8    16
9   9    18
10 10    20
11 11    22
> tr %<>% tidytree::left_join(da, by=c("node"="id"))
> tr
'treedata' S4 object'.

...@ phylo:

Phylogenetic tree with 6 tips and 5 internal nodes.

Tip labels:
  t5, t2, t3, t1, t4, t6

Rooted; includes branch lengths.

with the following features available:
        '',     'value'.

# The associated data tibble abstraction: 11 × 4
# The 'node', 'label' and 'isTip' are from the phylo tree.
    node label isTip value
   <int> <chr> <lgl> <dbl>
 1     1 t5    TRUE      2
 2     2 t2    TRUE      4
 3     3 t3    TRUE      6
 4     4 t1    TRUE      8
 5     5 t4    TRUE     10
 6     6 t6    TRUE     12
 7     7 NA    FALSE    14
 8     8 NA    FALSE    16
 9     9 NA    FALSE    18
10    10 NA    FALSE    20
11    11 NA    FALSE    22
> tr %>% root(outgroup="t6")
'treedata' S4 object'.

...@ phylo:

Phylogenetic tree with 6 tips and 4 internal nodes.

Tip labels:
  t5, t2, t3, t1, t4, t6
Node labels:
  , NA, NA, NA

Unrooted; includes branch lengths.

with the following features available:
        '',     'value'.

# The associated data tibble abstraction: 10 × 4
# The 'node', 'label' and 'isTip' are from the phylo tree.
    node label isTip value
   <int> <chr> <lgl> <dbl>
 1     1 "t5"  TRUE      2
 2     2 "t2"  TRUE      4
 3     3 "t3"  TRUE      6
 4     4 "t1"  TRUE      8
 5     5 "t4"  TRUE     10
 6     6 "t6"  TRUE     12
 7     7 ""    FALSE    NA
 8     8  NA   FALSE    16
 9     9  NA   FALSE    20
10    10  NA   FALSE    22
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

