### PR TITLE
get read.beast to santise headers

### DIFF
--- a/R/beast.R
+++ b/R/beast.R
@@ -18,7 +18,13 @@ read.beast <- function(file, threads = 1, verbose = FALSE) {
 
     treetext <- read.treetext_beast(text)
     stats <- read.stats_beast(text, treetext, threads = threads, verbose = verbose)
+    if (verbose) {
+        cat("reading phylo...\n")
+    }
     phylo <- read.nexus(file)
+    if (verbose) {
+        cat("done reading phylo\n")
+    }
 
     if (length(treetext) == 1) {
         obj <- BEAST(file, treetext, stats, phylo)
@@ -204,6 +210,9 @@ read.stats_beast_internal <- function(text, is_translated, index = NULL, verbose
     ## BEAST1 edge stat fix
    	text <- gsub("\\]:\\[&(.+?\\])", ",\\1:", text, perl = use_perl())
     text <- gsub(":(\\[.+?\\])", "\\1:", text, perl = use_perl())
+
+    ## santise headers
+    text <- gsub(":[^\\[=]+=", "=", text, perl = use_perl())
 
     if (grepl("\\:[0-9\\.eEL+\\-]*\\[", text, perl = use_perl()) || grepl("\\]\\[", text, perl = use_perl())){
         pattern <- "(\\w+)?(:[\\+\\-]?\\d*\\.?\\d*[Ee]?[\\+\\-]?\\L*\\d*)?(\\[&.*?\\])"


### PR DESCRIPTION
BEAST2 by default puts partition names into parameter names in the fields. This means that output trees will often look as follows (this example is not real beast2 output, but is similar to what they look like):

```
begin taxa;
        DIMENSIONS NTAX = 4;
        TAXLABELS
a
b
c
d
        ;
END;
BEGIN TREES;
translate;
1 a
2 b
3 c
4 d
;
tree * UNTITLED = [&R] ((1[&blockcount.t:hi=0,blockstart.t:hi=0.2,blockend.t:hi=0.2]:1,2[&blockcount.t:hi=-1,blockstart.t:hi=0.5,blockend.t:hi=0.5]:1)[&blockcount.t:hi=-1,blockstart.t:hi=0.5,blockend.t:hi=0.5]:1,(3[&blockcount.t:hi=2,blockstart.t:hi=0.1,blockend.t:hi=0.5]:2,4[&blockcount.t:hi=1,blockstart.t:hi=0.5,blockend.t:hi=0.75]:1)[&blockcount.t:hi=0,blockstart.t:hi=0.5,blockend.t:hi=0.5]:1);
end;
```

Note the `:hi` appended to the parameter names. I've changed read.beast to strip these partition names when it reads in the file. Otherwise, it doesn't parse the parameters correctly since it splits the nodes on `:`s.

I also added a bit more logging for the verbose flag since running read.nexus can sometimes take a while.